### PR TITLE
Open tooltips with a long press on touch devices

### DIFF
--- a/projects/anglify/src/modules/tooltip/tooltip.interface.ts
+++ b/projects/anglify/src/modules/tooltip/tooltip.interface.ts
@@ -1,0 +1,1 @@
+export type TooltipTouchTrigger = 'short' | 'long';

--- a/projects/anglify/src/public-api.ts
+++ b/projects/anglify/src/public-api.ts
@@ -35,3 +35,4 @@ export * from './modules/stepper/services/stepper-settings/stepper-settings.serv
 
 export * from './modules/tooltip/tooltip.module';
 export * from './modules/tooltip/tooltip.directive';
+export * from './modules/tooltip/tooltip.interface';

--- a/projects/anglify/src/utils/functions.ts
+++ b/projects/anglify/src/utils/functions.ts
@@ -24,3 +24,7 @@ export function observeOnResize(target: Element): Observable<ResizeObserverEntry
 export function isBooleanLikeTrue(value: BooleanLike): boolean {
   return value === true || value === 'true' || value === '';
 }
+
+export function isTouchDevice(): boolean {
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+}


### PR DESCRIPTION
By default, tooltips are now opened by a long click on mobile devices.
However, this can be configured through the `tooltipMobileTrigger` property (pass either `short` or `long`)

Closes #42