### PR TITLE
refactor(tooltip): Extract tooltip positioning into own service

### DIFF
--- a/projects/anglify/src/composables/position/position.interface.ts
+++ b/projects/anglify/src/composables/position/position.interface.ts
@@ -1,0 +1,5 @@
+export interface PositionSettings {
+  host: HTMLElement;
+}
+
+export type Position = 'top' | 'right' | 'bottom' | 'left';

--- a/projects/anglify/src/composables/position/position.provider.ts
+++ b/projects/anglify/src/composables/position/position.provider.ts
@@ -1,0 +1,10 @@
+import { ElementRef } from '@angular/core';
+import { PositionService } from './position.service';
+import { POSITION_SETTINGS } from './position.token';
+import { PositionSettings } from './position.interface';
+
+export const MENUABLE = {
+  provide: PositionService,
+  useFactory: (el: ElementRef, settings: PositionSettings) => new PositionService(el as ElementRef<HTMLElement>, settings),
+  deps: [ElementRef, POSITION_SETTINGS],
+};

--- a/projects/anglify/src/composables/position/position.service.ts
+++ b/projects/anglify/src/composables/position/position.service.ts
@@ -1,0 +1,56 @@
+import { ElementRef, Inject, Injectable } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { POSITION_SETTINGS } from './position.token';
+import { PositionSettings, Position } from './position.interface';
+import { fromEvent, merge } from 'rxjs';
+import { observeOnResize } from '../../utils/functions';
+
+@UntilDestroy()
+@Injectable()
+export class PositionService {
+  private _position: Position = 'top';
+  private _offset = 10;
+
+  public set position(value: Position) {
+    this._position = value;
+    this.updatePosition();
+  }
+
+  public set offset(value: number) {
+    this._offset = value;
+    this.updatePosition();
+  }
+
+  public constructor(
+    private readonly _elementRef: ElementRef<HTMLElement>,
+    @Inject(POSITION_SETTINGS) private readonly settings: PositionSettings
+  ) {
+    merge(observeOnResize(this._elementRef.nativeElement), fromEvent(window, 'scroll', { capture: true }))
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.updatePosition());
+  }
+
+  private updatePosition(): void {
+    const hostPos = this.settings.host.getBoundingClientRect();
+    const menuPos = this._elementRef.nativeElement.getBoundingClientRect();
+    let top;
+    let left;
+
+    if (this._position === 'top') {
+      top = hostPos.top - menuPos.height - this._offset;
+      left = Math.max(Number(hostPos.left) + (hostPos.width - menuPos.width) / 2, this._offset);
+    } else if (this._position === 'bottom') {
+      top = Number(hostPos.bottom) + this._offset;
+      left = Math.max(Number(hostPos.left) + (hostPos.width - menuPos.width) / 2, this._offset);
+    } else {
+      top = Number(hostPos.top) + (hostPos.height - menuPos.height) / 2;
+      if (this._position === 'left') {
+        left = Math.max(hostPos.left - menuPos.width - this._offset, this._offset);
+      } else {
+        left = Math.min(Number(hostPos.right) + this._offset, window.innerWidth - menuPos.width - this._offset);
+      }
+    }
+    this._elementRef.nativeElement.style.top = `${top}px`;
+    this._elementRef.nativeElement.style.left = `${left}px`;
+  }
+}

--- a/projects/anglify/src/composables/position/position.token.ts
+++ b/projects/anglify/src/composables/position/position.token.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { PositionSettings } from './position.interface';
+
+export const POSITION_SETTINGS = new InjectionToken<PositionSettings>('Position settings');

--- a/projects/anglify/src/modules/tooltip/components/tooltip/tooltip.component.ts
+++ b/projects/anglify/src/modules/tooltip/components/tooltip/tooltip.component.ts
@@ -1,9 +1,8 @@
-import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
-import { TooltipPosition } from '../../tooltip.interface';
-import { observeOnResize } from '../../../../utils/functions';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { fromEvent, merge } from 'rxjs';
-import { DEFAULT_TOOLTIP_SETTINGS } from '../../tooltip-settings.token';
+import { ChangeDetectionStrategy, Component, ElementRef, HostBinding, Input, ViewEncapsulation } from '@angular/core';
+import { UntilDestroy } from '@ngneat/until-destroy';
+import { Position } from '../../../../composables/position/position.interface';
+import { MENUABLE } from '../../../../composables/position/position.provider';
+import { PositionService } from '../../../../composables/position/position.service';
 
 @UntilDestroy()
 @Component({
@@ -12,52 +11,24 @@ import { DEFAULT_TOOLTIP_SETTINGS } from '../../tooltip-settings.token';
   styleUrls: ['./tooltip.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
+  providers: [MENUABLE],
 })
-export class TooltipComponent implements OnInit {
-  @Input() public position: TooltipPosition = DEFAULT_TOOLTIP_SETTINGS.position;
-  @Input() public offset = DEFAULT_TOOLTIP_SETTINGS.defaultOffset;
+export class TooltipComponent {
+  @Input()
+  public set position(value: Position) {
+    this.positionService.position = value;
+  }
+
+  @Input()
+  public set offset(value: number) {
+    this.positionService.offset = value;
+  }
 
   @HostBinding('class')
   @Input()
   public contentClass?: string;
 
-  public constructor(@Inject('tooltipConfig') private readonly config: any, private readonly element: ElementRef) {
+  public constructor(private readonly positionService: PositionService, private readonly element: ElementRef) {
     this.element.nativeElement.classList.add('anglify-tooltip');
-
-    merge(observeOnResize(this.element.nativeElement as HTMLElement), fromEvent(window, 'scroll', { capture: true }))
-      .pipe(untilDestroyed(this))
-      .subscribe(() => this.updatePosition()); // Used to center dynamic content inside tooltip
-  }
-
-  public ngOnInit(): void {
-    this.updatePosition();
-  }
-
-  private updatePosition(): TooltipComponent {
-    const hostPos = this.config.host.getBoundingClientRect();
-    const tooltipPos = this.element.nativeElement.getBoundingClientRect();
-
-    let top;
-    let left;
-
-    if (this.position === 'top') {
-      top = hostPos.top - tooltipPos.height - this.offset;
-      left = Math.max(Number(hostPos.left) + (hostPos.width - tooltipPos.width) / 2, this.offset);
-    } else if (this.position === 'bottom') {
-      top = Number(hostPos.bottom) + this.offset;
-      left = Math.max(Number(hostPos.left) + (hostPos.width - tooltipPos.width) / 2, this.offset);
-    } else {
-      top = Number(hostPos.top) + (hostPos.height - tooltipPos.height) / 2;
-      if (this.position === 'left') {
-        left = Math.max(hostPos.left - tooltipPos.width - this.offset, this.offset);
-      } else {
-        left = Math.min(Number(hostPos.right) + this.offset, window.innerWidth - tooltipPos.width - this.offset);
-      }
-    }
-
-    this.element.nativeElement.style.top = `${top}px`;
-    this.element.nativeElement.style.left = `${left}px`;
-
-    return this;
   }
 }

--- a/projects/anglify/src/modules/tooltip/tooltip.directive.spec.ts
+++ b/projects/anglify/src/modules/tooltip/tooltip.directive.spec.ts
@@ -1,8 +1,0 @@
-import { TooltipDirective } from './tooltip.directive';
-
-describe('TooltipDirective', () => {
-  it('should create an instance', () => {
-    const directive = TooltipDirective;
-    expect(directive).toBeTruthy();
-  });
-});

--- a/projects/anglify/src/modules/tooltip/tooltip.directive.ts
+++ b/projects/anglify/src/modules/tooltip/tooltip.directive.ts
@@ -23,8 +23,10 @@ import { delay, mergeMap, repeat, takeUntil, tap } from 'rxjs/operators';
 import { isBooleanLikeTrue, isTouchDevice } from '../../utils/functions';
 import { BooleanLike } from '../../utils/interfaces';
 import { DEFAULT_TOOLTIP_SETTINGS, TOOLTIP_SETTINGS } from './tooltip-settings.token';
-import { TooltipPosition, TooltipSettings, TooltipTouchTrigger } from './tooltip.interface';
+import { TooltipSettings, TooltipTouchTrigger } from './tooltip.interface';
 import { TooltipComponent } from './components/tooltip/tooltip.component';
+import { Position } from '../../composables/position/position.interface';
+import { POSITION_SETTINGS } from '../../composables/position/position.token';
 
 @UntilDestroy()
 @Directive({
@@ -58,14 +60,14 @@ export class TooltipDirective implements OnDestroy {
   }
 
   @Input()
-  public set position(value: TooltipPosition) {
+  public set position(value: Position) {
     this._position = value;
     if (this.componentRef) {
       this.componentRef.instance.position = value;
     }
   }
 
-  public get position(): TooltipPosition {
+  public get position(): Position {
     return this._position;
   }
 
@@ -81,7 +83,7 @@ export class TooltipDirective implements OnDestroy {
     return this._contentClass;
   }
 
-  private _position: TooltipPosition = DEFAULT_TOOLTIP_SETTINGS.position;
+  private _position: Position = DEFAULT_TOOLTIP_SETTINGS.position;
   private _offset = DEFAULT_TOOLTIP_SETTINGS.defaultOffset;
   private _contentClass?: string;
 
@@ -205,7 +207,7 @@ export class TooltipDirective implements OnDestroy {
     if (this.componentRef) return;
     const factory = this.resolver.resolveComponentFactory(TooltipComponent);
     const injector = Injector.create({
-      providers: [{ provide: 'tooltipConfig', useValue: { host: this.element.nativeElement } }],
+      providers: [{ provide: POSITION_SETTINGS, useValue: { host: this.element.nativeElement } }],
     });
     this.componentRef = this.viewContainerRef.createComponent(factory, 0, injector, this.generateNgContent());
     this.componentRef.instance.position = this.position;

--- a/projects/anglify/src/modules/tooltip/tooltip.interface.ts
+++ b/projects/anglify/src/modules/tooltip/tooltip.interface.ts
@@ -1,11 +1,11 @@
-export type TooltipTouchTrigger = 'short' | 'long';
+import { Position } from '../../composables/position/position.interface';
 
-export type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
+export type TooltipTouchTrigger = 'short' | 'long';
 
 export type TooltipMountingPoint = HTMLElement | 'body' | 'parent';
 
 export interface TooltipSettings {
-  position?: TooltipPosition;
+  position?: Position;
   hoverOpenDelay?: number;
   touchOpenDelay?: number;
   hoverCloseDelay?: number;


### PR DESCRIPTION
To make Anglify more modular and reusable, positioning is extracted into a service. This allows other components to use it as well

Close #57