### PR TITLE
refactor: unify content projection

### DIFF
--- a/apps/docs/src/app/examples/checkbox/custom-icons/custom-icons.component.html
+++ b/apps/docs/src/app/examples/checkbox/custom-icons/custom-icons.component.html
@@ -1,11 +1,17 @@
 <anglify-checkbox checked>Check me!</anglify-checkbox>
 <anglify-checkbox checked ripple="false">No ripple!</anglify-checkbox>
 <anglify-checkbox checked>
-  <anglify-icon onIcon icon="mdi-cards-heart"></anglify-icon>
+  <ng-template slot="onIcon">
+    <anglify-icon icon="mdi-cards-heart"></anglify-icon>
+  </ng-template>
   Custom On, Global Off Icon
 </anglify-checkbox>
 <anglify-checkbox checked>
-  <anglify-icon onIcon icon="mdi-bookmark"></anglify-icon>
-  <anglify-icon offIcon icon="mdi-bookmark-outline"></anglify-icon>
+  <ng-template slot="onIcon">
+    <anglify-icon icon="mdi-bookmark"></anglify-icon>
+  </ng-template>
+  <ng-template slot="offIcon">
+    <anglify-icon icon="mdi-bookmark-outline"></anglify-icon>
+  </ng-template>
   Custom Icon!
 </anglify-checkbox>

--- a/apps/docs/src/app/examples/checkbox/sizes/sizes.component.html
+++ b/apps/docs/src/app/examples/checkbox/sizes/sizes.component.html
@@ -2,7 +2,11 @@
 <anglify-checkbox checked class="checkbox-medium">Check me!</anglify-checkbox>
 <anglify-checkbox checked class="checkbox-large"> Check me! </anglify-checkbox>
 <anglify-checkbox checked class="checkbox-x-large" ripple="false">
-  <anglify-icon onIcon icon="mdi-cards-heart"></anglify-icon>
-  <anglify-icon offIcon icon="mdi-cards-heart-outline"></anglify-icon>
+  <ng-template slot="onIcon">
+    <anglify-icon icon="mdi-cards-heart"></anglify-icon>
+  </ng-template>
+  <ng-template slot="offIcon">
+    <anglify-icon icon="mdi-cards-heart-outline"></anglify-icon>
+  </ng-template>
   No ripple!
 </anglify-checkbox>

--- a/apps/docs/src/app/examples/form-field/icons/icons.component.html
+++ b/apps/docs/src/app/examples/form-field/icons/icons.component.html
@@ -1,31 +1,55 @@
-<anglify-form-field type="filled" prepend-icon="mdi-email" label="Prepend">
+<anglify-form-field type="filled" label="Prepend">
+  <ng-template slot="prepend-inner">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="outlined" prepend-icon="mdi-email" label="Prepend">
+<anglify-form-field type="outlined" label="Prepend">
+  <ng-template slot="prepend-inner">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="filled" prepend-outer-icon="mdi-email" label="Prepend outer">
+<anglify-form-field type="filled" label="Prepend outer">
+  <ng-template slot="prepend">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="outlined" prepend-outer-icon="mdi-email" label="Prepend outer">
+<anglify-form-field type="outlined" label="Prepend outer">
+  <ng-template slot="prepend">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="filled" append-icon="mdi-email" label="Append">
+<anglify-form-field type="filled" label="Append">
+  <ng-template slot="append-inner">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="outlined" append-icon="mdi-email" label="Append">
+<anglify-form-field type="outlined" label="Append">
+  <ng-template slot="append-inner">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="filled" append-outer-icon="mdi-email" label="Append outer">
+<anglify-form-field type="filled" label="Append outer">
+  <ng-template slot="append">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>
 
-<anglify-form-field type="outlined" append-outer-icon="mdi-email" label="Append outer">
+<anglify-form-field type="outlined" label="Append outer">
+  <ng-template slot="append">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="Placeholder" />
 </anglify-form-field>

--- a/apps/docs/src/app/examples/form-field/label-slot/label-slot.component.html
+++ b/apps/docs/src/app/examples/form-field/label-slot/label-slot.component.html
@@ -1,5 +1,5 @@
 <anglify-form-field type="filled">
-  <ng-template anglifyLabel>
+  <ng-template slot="label">
     What about a icon here?
     <anglify-icon icon="mdi-email"></anglify-icon>
   </ng-template>
@@ -7,7 +7,7 @@
 </anglify-form-field>
 
 <anglify-form-field type="filled">
-  <ng-template anglifyLabel>
+  <ng-template slot="label">
     What about a icon here?
     <anglify-icon icon="mdi-email"></anglify-icon>
   </ng-template>

--- a/apps/docs/src/app/examples/form-field/prefix-and-suffix/prefix-and-suffix.component.html
+++ b/apps/docs/src/app/examples/form-field/prefix-and-suffix/prefix-and-suffix.component.html
@@ -6,16 +6,19 @@
   <input anglifyInput />
 </anglify-form-field>
 
-<anglify-form-field type="outlined" suffix="kg" prepend-icon="mdi-scale-bathroom" label="Weight">
+<anglify-form-field type="outlined" suffix="kg" label="Weight">
+  <ng-template slot="prepend-inner">
+    <anglify-icon icon="mdi-scale-bathroom"></anglify-icon>
+  </ng-template>
   <input anglifyInput />
 </anglify-form-field>
 
-<anglify-form-field
-  type="outlined"
-  prepend-icon="mdi-email"
-  suffix="@example.com"
-  append-icon="mdi-dots-horizontal-circle-outline"
-  persistent-placeholder
->
+<anglify-form-field type="outlined" suffix="@example.com" persistent-placeholder>
+  <ng-template slot="prepend-inner">
+    <anglify-icon icon="mdi-email"></anglify-icon>
+  </ng-template>
+  <ng-template slot="append-inner">
+    <anglify-icon icon="mdi-dots-horizontal-circle-outline"></anglify-icon>
+  </ng-template>
   <input anglifyInput placeholder="john.doe" style="text-align: end" />
 </anglify-form-field>

--- a/apps/docs/src/app/examples/list/actions/actions.component.html
+++ b/apps/docs/src/app/examples/list/actions/actions.component.html
@@ -3,7 +3,7 @@
   <anglify-list>
     <anglify-list-item-group multiple>
       <anglify-list-item state="false">
-        <ng-template anglifyPrepend let-active="active">
+        <ng-template slot="prepend" let-active="active">
           <anglify-checkbox [checked]="active" readonly></anglify-checkbox>
         </ng-template>
         <anglify-list-item-title>Notifications</anglify-list-item-title>
@@ -12,14 +12,14 @@
         </anglify-list-item-description>
       </anglify-list-item>
       <anglify-list-item state="false">
-        <ng-template anglifyPrepend let-active="active">
+        <ng-template slot="prepend" let-active="active">
           <anglify-checkbox [checked]="active" readonly></anglify-checkbox>
         </ng-template>
         <anglify-list-item-title>Updates</anglify-list-item-title>
         <anglify-list-item-description [lineClamp]="2">Auto-update apps at any time. Data charges may apply </anglify-list-item-description>
       </anglify-list-item>
       <anglify-list-item state="false">
-        <ng-template anglifyPrepend let-active="active">
+        <ng-template slot="prepend" let-active="active">
           <anglify-checkbox [checked]="active" readonly></anglify-checkbox>
         </ng-template>
         <anglify-list-item-title>Auto-add widgets</anglify-list-item-title>

--- a/apps/docs/src/app/examples/list/groups/groups.component.html
+++ b/apps/docs/src/app/examples/list/groups/groups.component.html
@@ -1,19 +1,19 @@
 <anglify-list>
   <anglify-list-item-group>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-clock"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Real time</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-account"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Audience</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-flag"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Conversions</anglify-list-item-title>

--- a/apps/docs/src/app/examples/list/mandatory/mandatory.component.html
+++ b/apps/docs/src/app/examples/list/mandatory/mandatory.component.html
@@ -1,19 +1,19 @@
 <anglify-list>
   <anglify-list-item-group mandatory>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-clock"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Real time</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-account"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Audience</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-flag"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Conversions</anglify-list-item-title>

--- a/apps/docs/src/app/examples/list/multiple-mandatory/multiple-mandatory.component.html
+++ b/apps/docs/src/app/examples/list/multiple-mandatory/multiple-mandatory.component.html
@@ -1,19 +1,19 @@
 <anglify-list>
   <anglify-list-item-group multiple mandatory>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-clock"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Real time</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-account"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Audience</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-flag"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Conversions</anglify-list-item-title>

--- a/apps/docs/src/app/examples/list/multiple/multiple.component.html
+++ b/apps/docs/src/app/examples/list/multiple/multiple.component.html
@@ -1,19 +1,19 @@
 <anglify-list>
   <anglify-list-item-group multiple>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-clock"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Real time</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-account"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Audience</anglify-list-item-title>
     </anglify-list-item>
     <anglify-list-item>
-      <ng-template anglifyPrepend>
+      <ng-template slot="prepend">
         <anglify-icon icon="mdi-flag"></anglify-icon>
       </ng-template>
       <anglify-list-item-title>Conversions</anglify-list-item-title>

--- a/apps/docs/src/app/pages/component-pages/form-field-page/form-field-page.component.html
+++ b/apps/docs/src/app/pages/component-pages/form-field-page/form-field-page.component.html
@@ -10,18 +10,18 @@
       [hide-details]="hideDetails"
       [hint]="hint"
     >
-      <ng-template anglifyPrependIcon>
+      <ng-template slot="prepend-inner">
         <anglify-icon [icon]="prependIcon ? 'mdi-home' : ''"></anglify-icon>
       </ng-template>
-      <ng-template anglifyPrependOuterIcon>
+      <ng-template slot="prepend">
         <anglify-icon [icon]="prependOuterIcon ? 'mdi-home' : ''"></anglify-icon>
       </ng-template>
-      <ng-template anglifyLabel>{{ label }}</ng-template>
+      <ng-template slot="label">{{ label }}</ng-template>
       <input anglifyInput [readonly]="readonly" [disabled]="disabled" [placeholder]="placeholder" />
-      <ng-template anglifyAppendIcon>
+      <ng-template slot="append-inner">
         <anglify-icon [icon]="appendIcon ? 'mdi-home' : ''"></anglify-icon>
       </ng-template>
-      <ng-template anglifyAppendOuterIcon>
+      <ng-template slot="append">
         <anglify-icon [icon]="appendOuterIcon ? 'mdi-home' : ''"></anglify-icon>
       </ng-template>
     </anglify-form-field>

--- a/apps/docs/src/app/pages/component-pages/list-page/list-page.component.html
+++ b/apps/docs/src/app/pages/component-pages/list-page/list-page.component.html
@@ -2,45 +2,6 @@
 
 <h2>Examples</h2>
 
-<anglify-list>
-  <anglify-list-item>
-    <anglify-list-item-title>One Line Item</anglify-list-item-title>
-  </anglify-list-item>
-</anglify-list>
-
-<anglify-list>
-  <anglify-list-item>
-    <ng-template anglifyPrepend>
-      <anglify-icon icon="mdi-heart"></anglify-icon>
-    </ng-template>
-    <anglify-list-item-title>One Line Item with prepend icon</anglify-list-item-title>
-  </anglify-list-item>
-</anglify-list>
-
-<anglify-list>
-  <anglify-list-item>
-    <anglify-list-item-title>One Line Item with append icon</anglify-list-item-title>
-    <ng-template anglifyAppend>
-      <anglify-icon icon="mdi-heart"></anglify-icon>
-    </ng-template>
-  </anglify-list-item>
-</anglify-list>
-
-<anglify-list dense>
-  <anglify-list-item (click)="doSomething()">
-    <anglify-list-item-title>One Line Item</anglify-list-item-title>
-  </anglify-list-item>
-</anglify-list>
-
-<anglify-list>
-  <anglify-list-item>
-    <anglify-list-item-title>Two Line Item</anglify-list-item-title>
-    <anglify-list-item-description>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
-    </anglify-list-item-description>
-  </anglify-list-item>
-</anglify-list>
-
 <h3>Standard Group</h3>
 <app-code-example component="list" example="groups"></app-code-example>
 

--- a/libs/anglify/src/index.ts
+++ b/libs/anglify/src/index.ts
@@ -15,6 +15,14 @@ export * from './modules/checkbox/tokens/checkbox.token';
 export * from './modules/checkbox/checkbox.component';
 export * from './modules/checkbox/functions/register-icons.function';
 export * from './modules/checkbox/checkbox.module';
+// Common
+export * from './modules/common/directives/slot/slot.directive';
+export * from './modules/common/directives/slot-outlet/slot-outlet.directive';
+export * from './modules/common/pipes/boolean-like-to-boolean/boolean-like-to-boolean.pipe';
+export * from './modules/common/pipes/clamp/clamp.pipe';
+export * from './modules/common/pipes/find-slot/find-slot.pipe';
+export * from './modules/common/pipes/percent/percent.pipe';
+export * from './modules/common/anglify-common.module';
 // Dialog
 export * from './modules/dialog/dialog-context.interface';
 export * from './modules/dialog/dialog-options.interface';
@@ -23,11 +31,6 @@ export * from './modules/dialog/dialog.service';
 export * from './modules/dialog/dialog.module';
 // Form Field
 export * from './modules/form-field/directives/input.directive';
-export * from './modules/form-field/directives/label/label.directive';
-export * from './modules/form-field/directives/icon/prepend-icon.directive';
-export * from './modules/form-field/directives/icon/prepend-outer-icon.directive';
-export * from './modules/form-field/directives/icon/append-icon.directive';
-export * from './modules/form-field/directives/icon/append-outer-icon.directive';
 export * from './modules/form-field/form-field-settings.token';
 export * from './modules/form-field/form-field.component';
 export * from './modules/form-field/form-field.interface';
@@ -43,8 +46,6 @@ export * from './modules/list/components/list-item/list-item.component';
 export * from './modules/list/components/list-item-description/list-item-description.component';
 export * from './modules/list/components/list-item-group/list-item-group.component';
 export * from './modules/list/components/list-item-title/list-item-title.component';
-export * from './modules/list/directives/append/append.directive';
-export * from './modules/list/directives/prepend/prepend.directive';
 export * from './modules/list/list.module';
 // Menu
 export * from './modules/menu/components/menu/menu.component';
@@ -78,7 +79,6 @@ export * from './modules/stepper/components/stepper/stepper.component';
 export * from './modules/stepper/directives/step/step.directive';
 export * from './modules/stepper/directives/stepper-next/stepper-next.directive';
 export * from './modules/stepper/directives/stepper-previous/stepper-previous.directive';
-export * from './modules/stepper/directives/stepper-visited-icon/stepper-visited-icon.directive';
 export * from './modules/stepper/services/stepper-settings/stepper-settings.service';
 export * from './modules/stepper/services/stepper/stepper.service';
 export * from './modules/stepper/stepper-testing.module';

--- a/libs/anglify/src/modules/checkbox/checkbox.component.html
+++ b/libs/anglify/src/modules/checkbox/checkbox.component.html
@@ -14,10 +14,10 @@
       [state]="state | booleanLikeToBoolean"
     ></div>
     <span #reflectOffIcon [style.display]="!(checked | booleanLikeToBoolean) ? 'block' : 'none'" class="checkbox-custom-icons">
-      <ng-content select="[offIcon]"></ng-content>
+      <ng-container *anglifySlotOutlet="slots | findSlot: 'offIcon'"></ng-container>
     </span>
     <span #reflectOnIcon [style.display]="(checked | booleanLikeToBoolean) ? 'block' : 'none'" class="checkbox-custom-icons">
-      <ng-content select="[onIcon]"></ng-content>
+      <ng-container *anglifySlotOutlet="slots | findSlot: 'onIcon'"></ng-container>
     </span>
     <span #offIcon [style.display]="!(checked | booleanLikeToBoolean) ? 'block' : 'none'" class="checkbox-custom-icons"></span>
     <span #onIcon [style.display]="(checked | booleanLikeToBoolean) ? 'block' : 'none'" class="checkbox-custom-icons"></span>
@@ -27,5 +27,3 @@
     <ng-content></ng-content>
   </span>
 </label>
-
-<ng-template #default> </ng-template>

--- a/libs/anglify/src/modules/checkbox/checkbox.component.ts
+++ b/libs/anglify/src/modules/checkbox/checkbox.component.ts
@@ -2,6 +2,7 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  ContentChildren,
   ElementRef,
   EventEmitter,
   forwardRef,
@@ -9,6 +10,7 @@ import {
   Input,
   Optional,
   Output,
+  QueryList,
   Renderer2,
   Self,
   ViewChild,
@@ -22,6 +24,7 @@ import { RippleOrigin } from '../../composables/ripple/ripple.interface';
 import { createSettingsProvider } from '../../factories/settings.factory';
 import { toBoolean } from '../../utils/functions';
 import type { BooleanLike } from '../../utils/interfaces';
+import { SlotDirective } from '../common/directives/slot/slot.directive';
 
 @Component({
   selector: 'anglify-checkbox',
@@ -38,6 +41,8 @@ import type { BooleanLike } from '../../utils/interfaces';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckboxComponent implements ControlValueAccessor, AfterViewInit {
+  @ContentChildren(SlotDirective) public readonly slots?: QueryList<SlotDirective>;
+
   @ViewChild('offIcon', { read: ElementRef }) public offIcon!: ElementRef<HTMLElement>;
   @ViewChild('onIcon', { read: ElementRef }) public onIcon!: ElementRef<HTMLElement>;
   @ViewChild('defaultIcon') public defaultIcon!: ElementRef<HTMLElement>;

--- a/libs/anglify/src/modules/checkbox/checkbox.module.ts
+++ b/libs/anglify/src/modules/checkbox/checkbox.module.ts
@@ -8,7 +8,7 @@ import { InteractionStateModule } from '../interaction-state/interaction-state.m
 
 @NgModule({
   declarations: [CheckboxComponent],
-  imports: [CommonModule, FormsModule, IconModule, InteractionStateModule, AnglifyCommonModule],
-  exports: [CheckboxComponent, InteractionStateModule],
+  imports: [AnglifyCommonModule, CommonModule, FormsModule, IconModule, InteractionStateModule],
+  exports: [AnglifyCommonModule, CheckboxComponent, InteractionStateModule],
 })
 export class CheckboxModule {}

--- a/libs/anglify/src/modules/common/anglify-common.module.ts
+++ b/libs/anglify/src/modules/common/anglify-common.module.ts
@@ -1,12 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { SlotOutletDirective } from './directives/slot-outlet/slot-outlet.directive';
+import { SlotDirective } from './directives/slot/slot.directive';
 import { BooleanLikeToBooleanPipe } from './pipes/boolean-like-to-boolean/boolean-like-to-boolean.pipe';
 import { ClampPipe } from './pipes/clamp/clamp.pipe';
+import { FindSlotPipe } from './pipes/find-slot/find-slot.pipe';
 import { PercentPipe } from './pipes/percent/percent.pipe';
 
 @NgModule({
-  declarations: [BooleanLikeToBooleanPipe, PercentPipe, ClampPipe],
+  declarations: [BooleanLikeToBooleanPipe, PercentPipe, ClampPipe, SlotDirective, SlotOutletDirective, FindSlotPipe],
   imports: [CommonModule],
-  exports: [BooleanLikeToBooleanPipe, PercentPipe, ClampPipe],
+  exports: [BooleanLikeToBooleanPipe, PercentPipe, ClampPipe, SlotDirective, SlotOutletDirective, FindSlotPipe],
 })
 export class AnglifyCommonModule {}

--- a/libs/anglify/src/modules/common/directives/slot-outlet/slot-outlet.directive.spec.ts
+++ b/libs/anglify/src/modules/common/directives/slot-outlet/slot-outlet.directive.spec.ts
@@ -1,0 +1,8 @@
+import { SlotOutletDirective } from './slot-outlet.directive';
+
+describe('SlotOutletDirective', () => {
+  it('should create an instance', () => {
+    const directive = SlotOutletDirective;
+    expect(directive).toBeTruthy();
+  });
+});

--- a/libs/anglify/src/modules/common/directives/slot-outlet/slot-outlet.directive.ts
+++ b/libs/anglify/src/modules/common/directives/slot-outlet/slot-outlet.directive.ts
@@ -1,0 +1,29 @@
+import { Directive, EmbeddedViewRef, Input, OnChanges, SimpleChange, TemplateRef, ViewContainerRef } from '@angular/core';
+
+@Directive({
+  selector: '[anglifySlotOutlet]',
+})
+export class SlotOutletDirective implements OnChanges {
+  private viewRef: EmbeddedViewRef<any> | null = null;
+
+  @Input() public anglifySlotOutlet: TemplateRef<any> | undefined;
+  @Input() public anglifySlotOutletContext: Record<string, unknown> | null = null;
+
+  public constructor(private readonly viewContainerRef: ViewContainerRef, private readonly templateRef: TemplateRef<any>) {}
+
+  public ngOnChanges(changes: { anglifySlotOutlet?: SimpleChange; anglifySlotOutletContext?: SimpleChange }): void {
+    if (changes.anglifySlotOutlet) {
+      if (this.viewRef) {
+        this.viewContainerRef.remove(this.viewContainerRef.indexOf(this.viewRef));
+      }
+
+      if (this.anglifySlotOutlet) {
+        this.viewRef = this.viewContainerRef.createEmbeddedView(this.anglifySlotOutlet, this.anglifySlotOutletContext);
+      } else {
+        this.viewRef = this.viewContainerRef.createEmbeddedView(this.templateRef, this.anglifySlotOutletContext);
+      }
+    } else if (this.viewRef && changes.anglifySlotOutletContext && this.anglifySlotOutletContext) {
+      this.viewRef.context = this.anglifySlotOutletContext;
+    }
+  }
+}

--- a/libs/anglify/src/modules/common/directives/slot/slot.directive.spec.ts
+++ b/libs/anglify/src/modules/common/directives/slot/slot.directive.spec.ts
@@ -1,0 +1,33 @@
+import { QueryList, TemplateRef } from '@angular/core';
+import { SlotDirective } from './slot.directive';
+import { MockElementRef } from '../../../../mocks/element-ref.mock';
+describe('SlotDirective', () => {
+  const directive = SlotDirective;
+  it('should create an instance', () => {
+    expect(directive).toBeTruthy();
+  });
+
+  it('should return right slots', () => {
+    const elementRef = new MockElementRef();
+    const templateRef1 = { elementRef } as unknown as TemplateRef<any>;
+    const templateRef2 = { elementRef } as unknown as TemplateRef<any>;
+    const slot1 = new SlotDirective(templateRef1);
+    slot1.slot = 'slot1Name';
+    const slot2 = new SlotDirective(templateRef2);
+    slot2.slot = 'slot2Name';
+
+    const queryList = [slot1, slot2] as unknown as QueryList<SlotDirective>;
+
+    expect(SlotDirective.getSlot(queryList, 'slot1Name')).toBe(templateRef1);
+    expect(SlotDirective.getSlot(queryList, 'slot1Name')).not.toBe(templateRef2);
+    expect(SlotDirective.getSlot(queryList, 'slot2Name')).toBe(templateRef2);
+    expect(SlotDirective.getSlot(queryList, 'slot3Name')).toBe(undefined);
+  });
+
+  it('should return undefined, if no slots available', () => {
+    const queryList = [] as unknown as QueryList<SlotDirective>;
+
+    expect(SlotDirective.getSlot(undefined, 'slot1Name')).toBe(undefined);
+    expect(SlotDirective.getSlot(queryList, 'slot1Name')).toBe(undefined);
+  });
+});

--- a/libs/anglify/src/modules/common/directives/slot/slot.directive.ts
+++ b/libs/anglify/src/modules/common/directives/slot/slot.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, Input, QueryList, TemplateRef } from '@angular/core';
+
+@Directive({
+  selector: 'ng-template[slot]',
+})
+export class SlotDirective {
+  @Input() public slot: string | undefined;
+
+  public constructor(public readonly template: TemplateRef<any>) {}
+
+  public static getSlot(slots: QueryList<SlotDirective> | undefined, name: string): TemplateRef<any> | undefined {
+    const slot = slots?.find(s => s.slot === name);
+    return slot ? slot.template : undefined;
+  }
+}

--- a/libs/anglify/src/modules/common/pipes/find-slot/find-slot.pipe.spec.ts
+++ b/libs/anglify/src/modules/common/pipes/find-slot/find-slot.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { FindSlotPipe } from './find-slot.pipe';
+
+describe('FindSlotPipe', () => {
+  it('create an instance', () => {
+    const pipe = new FindSlotPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/libs/anglify/src/modules/common/pipes/find-slot/find-slot.pipe.ts
+++ b/libs/anglify/src/modules/common/pipes/find-slot/find-slot.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform, QueryList, TemplateRef } from '@angular/core';
+import { SlotDirective } from '../../directives/slot/slot.directive';
+
+@Pipe({
+  name: 'findSlot',
+})
+export class FindSlotPipe implements PipeTransform {
+  public transform(slots: QueryList<SlotDirective> | undefined, name: string): TemplateRef<any> | undefined {
+    return SlotDirective.getSlot(slots, name);
+  }
+}

--- a/libs/anglify/src/modules/dialog/dialog.component.ts
+++ b/libs/anglify/src/modules/dialog/dialog.component.ts
@@ -21,13 +21,10 @@ export class DialogComponent implements OnInit {
   private readonly dialogElement!: ElementRef<HTMLElement>;
 
   public constructor(
-    @Inject(DOCUMENT)
-    private readonly document: Document,
+    @Inject(DOCUMENT) private readonly document: Document,
     elementRef: ElementRef<HTMLElement>,
-    @Inject(DIALOG_CONTEXT)
-    private readonly context: DialogContext,
-    @Inject(DIALOG_NODES)
-    private readonly nodes: HTMLElement[]
+    @Inject(DIALOG_CONTEXT) private readonly context: DialogContext,
+    @Inject(DIALOG_NODES) private readonly nodes: HTMLElement[]
   ) {
     this.nodes.forEach(node => elementRef.nativeElement.appendChild(node));
   }

--- a/libs/anglify/src/modules/form-field/directives/icon/append-icon.directive.ts
+++ b/libs/anglify/src/modules/form-field/directives/icon/append-icon.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyAppendIcon]',
-})
-export class AppendIconDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/form-field/directives/icon/append-outer-icon.directive.ts
+++ b/libs/anglify/src/modules/form-field/directives/icon/append-outer-icon.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyAppendOuterIcon]',
-})
-export class AppendOuterIconDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/form-field/directives/icon/prepend-icon.directive.ts
+++ b/libs/anglify/src/modules/form-field/directives/icon/prepend-icon.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyPrependIcon]',
-})
-export class PrependIconDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/form-field/directives/icon/prepend-outer-icon.directive.ts
+++ b/libs/anglify/src/modules/form-field/directives/icon/prepend-outer-icon.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyPrependOuterIcon]',
-})
-export class PrependOuterIconDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/form-field/directives/label/label.directive.ts
+++ b/libs/anglify/src/modules/form-field/directives/label/label.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyLabel]',
-})
-export class LabelDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/form-field/form-field.component.html
+++ b/libs/anglify/src/modules/form-field/form-field.component.html
@@ -1,33 +1,35 @@
 <div class="outer-prepend">
-  <ng-container *ngTemplateOutlet="prependOuterIconTemplate"></ng-container>
+  <ng-container *anglifySlotOutlet="slots | findSlot: 'prepend'"></ng-container>
 </div>
 <div class="form-field-container">
   <div class="form-field-border">
     <div class="start"></div>
     <div class="notch" *ngIf="type === 'outlined'">
       <span>
-        <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+        <ng-container *anglifySlotOutlet="slots | findSlot: 'label'"></ng-container>
       </span>
     </div>
     <div class="end"></div>
   </div>
   <div class="prepend" #prependItem>
-    <ng-container *ngTemplateOutlet="prependIconTemplate"></ng-container>
+    <ng-container *anglifySlotOutlet="slots | findSlot: 'prepend-inner'"></ng-container>
     <ng-container *ngIf="prefix">{{ prefix }}</ng-container>
   </div>
   <label>
-    <span class="label" *ngIf="labelDirective || label" [style.margin-inline-start]="outlinedLabelPrefixMargin$ | async">
-      <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+    <span class="label" *ngIf="(slots | findSlot: 'label') || label" [style.margin-inline-start]="outlinedLabelPrefixMargin$ | async">
+      <ng-container *anglifySlotOutlet="slots | findSlot: 'label'">
+        {{ label }}
+      </ng-container>
     </span>
     <ng-content select="[anglifyInput]"></ng-content>
   </label>
   <div class="append">
     <ng-container *ngIf="suffix">{{ suffix }}</ng-container>
-    <ng-container *ngTemplateOutlet="appendIconTemplate"></ng-container>
+    <ng-container *anglifySlotOutlet="slots | findSlot: 'append-inner'"></ng-container>
   </div>
 </div>
 <div class="outer-append">
-  <ng-container *ngTemplateOutlet="appendOuterIconTemplate"></ng-container>
+  <ng-container *anglifySlotOutlet="slots | findSlot: 'append'"></ng-container>
 </div>
 <div class="details">
   <div class="hint">
@@ -40,29 +42,3 @@
     {{ input?.length$ | async }}<span *ngIf="input?.maxLength$ | async as maxLength">/{{ maxLength }}</span>
   </div>
 </div>
-<ng-template #labelTemplate>
-  <ng-container *ngIf="labelDirective">
-    <ng-container *ngTemplateOutlet="labelDirective.template"></ng-container>
-  </ng-container>
-  {{ label }}
-</ng-template>
-<ng-template #prependIconTemplate>
-  <ng-container *ngIf="prependIconDirective">
-    <ng-container *ngTemplateOutlet="prependIconDirective.template"></ng-container>
-  </ng-container>
-</ng-template>
-<ng-template #prependOuterIconTemplate>
-  <ng-container *ngIf="prependOuterIconDirective">
-    <ng-container *ngTemplateOutlet="prependOuterIconDirective.template"></ng-container>
-  </ng-container>
-</ng-template>
-<ng-template #appendIconTemplate>
-  <ng-container *ngIf="appendIconDirective">
-    <ng-container *ngTemplateOutlet="appendIconDirective.template"></ng-container>
-  </ng-container>
-</ng-template>
-<ng-template #appendOuterIconTemplate>
-  <ng-container *ngIf="appendOuterIconDirective">
-    <ng-container *ngTemplateOutlet="appendOuterIconDirective.template"></ng-container>
-  </ng-container>
-</ng-template>

--- a/libs/anglify/src/modules/form-field/form-field.component.ts
+++ b/libs/anglify/src/modules/form-field/form-field.component.ts
@@ -4,27 +4,25 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChild,
+  ContentChildren,
   ElementRef,
   HostBinding,
   Inject,
   Input,
+  QueryList,
   Self,
   ViewChild,
 } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { BehaviorSubject, combineLatest } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
-import { AppendIconDirective } from './directives/icon/append-icon.directive';
-import { AppendOuterIconDirective } from './directives/icon/append-outer-icon.directive';
-import { PrependIconDirective } from './directives/icon/prepend-icon.directive';
-import { PrependOuterIconDirective } from './directives/icon/prepend-outer-icon.directive';
 import { InputDirective } from './directives/input.directive';
-import { LabelDirective } from './directives/label/label.directive';
 import { DEFAULT_FORM_FIELD_SETTINGS, FORM_FIELD_SETTINGS } from './form-field-settings.token';
 import type { FormFieldSettings, FormFieldType } from './form-field.interface';
 import { createSettingsProvider } from '../../factories/settings.factory';
 import { toBoolean } from '../../utils/functions';
 import type { BooleanLike } from '../../utils/interfaces';
+import { SlotDirective } from '../common/directives/slot/slot.directive';
 
 @UntilDestroy()
 @Component({
@@ -35,13 +33,10 @@ import type { BooleanLike } from '../../utils/interfaces';
   providers: [createSettingsProvider<FormFieldSettings>('anglifyFormFieldSettings', DEFAULT_FORM_FIELD_SETTINGS, FORM_FIELD_SETTINGS)],
 })
 export class FormFieldComponent implements AfterViewInit {
+  @ContentChildren(SlotDirective) public readonly slots?: QueryList<SlotDirective>;
   @ContentChild(InputDirective) public readonly input?: InputDirective;
-  @ContentChild(LabelDirective) public readonly labelDirective?: LabelDirective;
+
   @ViewChild('prependItem') public readonly prependItem?: ElementRef<HTMLElement>;
-  @ContentChild(PrependIconDirective) public prependIconDirective?: PrependIconDirective;
-  @ContentChild(PrependOuterIconDirective) public prependOuterIconDirective?: PrependOuterIconDirective;
-  @ContentChild(AppendIconDirective) public appendIconDirective?: AppendIconDirective;
-  @ContentChild(AppendOuterIconDirective) public appendOuterIconDirective?: AppendOuterIconDirective;
 
   @Input() public type: FormFieldType = this.settings.defaultType;
   @Input() public hint?: string;
@@ -99,7 +94,7 @@ export class FormFieldComponent implements AfterViewInit {
     if (toBoolean(this.dense)) {
       classNames.push('dense');
     }
-    if (this.labelDirective || this.label) {
+    if (SlotDirective.getSlot(this.slots, 'label') || this.label) {
       classNames.push('has-label');
     }
     if (toBoolean(this.hideDetails)) {

--- a/libs/anglify/src/modules/form-field/form-field.module.ts
+++ b/libs/anglify/src/modules/form-field/form-field.module.ts
@@ -1,33 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { AppendIconDirective } from './directives/icon/append-icon.directive';
-import { AppendOuterIconDirective } from './directives/icon/append-outer-icon.directive';
-import { PrependIconDirective } from './directives/icon/prepend-icon.directive';
-import { PrependOuterIconDirective } from './directives/icon/prepend-outer-icon.directive';
 import { InputDirective } from './directives/input.directive';
-import { LabelDirective } from './directives/label/label.directive';
 import { FormFieldComponent } from './form-field.component';
+import { AnglifyCommonModule } from '../common/anglify-common.module';
 import { IconModule } from '../icon/icon.module';
 
 @NgModule({
-  declarations: [
-    FormFieldComponent,
-    InputDirective,
-    LabelDirective,
-    PrependIconDirective,
-    PrependOuterIconDirective,
-    AppendIconDirective,
-    AppendOuterIconDirective,
-  ],
-  imports: [CommonModule, IconModule],
-  exports: [
-    FormFieldComponent,
-    InputDirective,
-    LabelDirective,
-    PrependIconDirective,
-    PrependOuterIconDirective,
-    AppendIconDirective,
-    AppendOuterIconDirective,
-  ],
+  declarations: [FormFieldComponent, InputDirective],
+  imports: [AnglifyCommonModule, CommonModule, IconModule],
+  exports: [AnglifyCommonModule, FormFieldComponent, InputDirective],
 })
 export class FormFieldModule {}

--- a/libs/anglify/src/modules/list/components/list-item/list-item.component.html
+++ b/libs/anglify/src/modules/list/components/list-item/list-item.component.html
@@ -1,9 +1,9 @@
-<div *ngIf="prependDirective" class="prepend">
-  <ng-container [ngTemplateOutlet]="prependDirective.template" [ngTemplateOutletContext]="{ active: active$ | async }"></ng-container>
+<div class="prepend">
+  <ng-container *anglifySlotOutlet="slots | findSlot: 'prepend'; context: { active: active$ | async }"></ng-container>
 </div>
 <div class="content">
   <ng-content></ng-content>
 </div>
-<div *ngIf="appendDirective" class="append">
-  <ng-container [ngTemplateOutlet]="appendDirective.template" [ngTemplateOutletContext]="{ active: active$ | async }"></ng-container>
+<div class="append">
+  <ng-container *anglifySlotOutlet="slots | findSlot: 'append'; context: { active: active$ | async }"></ng-container>
 </div>

--- a/libs/anglify/src/modules/list/components/list-item/list-item.component.ts
+++ b/libs/anglify/src/modules/list/components/list-item/list-item.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectionStrategy, Component, ContentChild, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ContentChildren,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  QueryList,
+} from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { BehaviorSubject, filter, map, switchMap, tap } from 'rxjs';
@@ -7,8 +17,7 @@ import { RippleService } from '../../../../composables/ripple/ripple.service';
 import { bindClassToNativeElement, toBoolean } from '../../../../utils/functions';
 import type { BooleanLike } from '../../../../utils/interfaces';
 import { filterEmpty } from '../../../../utils/operator-functions';
-import { AppendDirective } from '../../directives/append/append.directive';
-import { PrependDirective } from '../../directives/prepend/prepend.directive';
+import { SlotDirective } from '../../../common/directives/slot/slot.directive';
 
 @UntilDestroy()
 @Component({
@@ -19,8 +28,7 @@ import { PrependDirective } from '../../directives/prepend/prepend.directive';
   providers: [RIPPLE],
 })
 export class ListItemComponent {
-  @ContentChild(AppendDirective) public readonly appendDirective?: AppendDirective;
-  @ContentChild(PrependDirective) public readonly prependDirective?: PrependDirective;
+  @ContentChildren(SlotDirective) public readonly slots?: QueryList<SlotDirective>;
 
   @Input()
   public set active(value: BooleanLike) {

--- a/libs/anglify/src/modules/list/directives/append/append.directive.ts
+++ b/libs/anglify/src/modules/list/directives/append/append.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyAppend]',
-})
-export class AppendDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/list/directives/prepend/prepend.directive.ts
+++ b/libs/anglify/src/modules/list/directives/prepend/prepend.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyPrepend]',
-})
-export class PrependDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/list/list.module.ts
+++ b/libs/anglify/src/modules/list/list.module.ts
@@ -5,25 +5,15 @@ import { ListItemGroupComponent } from './components/list-item-group/list-item-g
 import { ListItemTitleComponent } from './components/list-item-title/list-item-title.component';
 import { ListItemComponent } from './components/list-item/list-item.component';
 import { ListComponent } from './components/list/list.component';
-import { AppendDirective } from './directives/append/append.directive';
-import { PrependDirective } from './directives/prepend/prepend.directive';
+import { AnglifyCommonModule } from '../common/anglify-common.module';
 
 @NgModule({
-  declarations: [
-    ListComponent,
-    ListItemComponent,
-    PrependDirective,
-    AppendDirective,
-    ListItemTitleComponent,
-    ListItemDescriptionComponent,
-    ListItemGroupComponent,
-  ],
-  imports: [CommonModule],
+  declarations: [ListComponent, ListItemComponent, ListItemTitleComponent, ListItemDescriptionComponent, ListItemGroupComponent],
+  imports: [AnglifyCommonModule, CommonModule],
   exports: [
+    AnglifyCommonModule,
     ListComponent,
     ListItemComponent,
-    PrependDirective,
-    AppendDirective,
     ListItemTitleComponent,
     ListItemDescriptionComponent,
     ListItemGroupComponent,

--- a/libs/anglify/src/modules/radio-button/radio-button.module.ts
+++ b/libs/anglify/src/modules/radio-button/radio-button.module.ts
@@ -7,7 +7,7 @@ import { InteractionStateModule } from '../interaction-state/interaction-state.m
 
 @NgModule({
   declarations: [RadioButtonComponent],
-  imports: [CommonModule, FormsModule, InteractionStateModule, AnglifyCommonModule],
-  exports: [RadioButtonComponent, InteractionStateModule],
+  imports: [AnglifyCommonModule, CommonModule, FormsModule, InteractionStateModule],
+  exports: [AnglifyCommonModule, RadioButtonComponent, InteractionStateModule],
 })
 export class RadioButtonModule {}

--- a/libs/anglify/src/modules/stepper/components/stepper-header/stepper-header.component.html
+++ b/libs/anglify/src/modules/stepper/components/stepper-header/stepper-header.component.html
@@ -3,7 +3,7 @@
   <div *ngIf="bottomStepConnectionLineVisible$ | async" class="step-connection-line bottom"></div>
   <div class="step-indicator">
     <div *ngIf="visited && (active$ | async) === false; else defaultIndicator">
-      <ng-container [ngTemplateOutlet]="stepperVisitedIcon.template"></ng-container>
+      <ng-container *anglifySlotOutlet="slots | findSlot: 'visitedIcon'"></ng-container>
     </div>
   </div>
 </div>

--- a/libs/anglify/src/modules/stepper/components/stepper-header/stepper-header.component.ts
+++ b/libs/anglify/src/modules/stepper/components/stepper-header/stepper-header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ContentChild, ElementRef, HostListener, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChildren, ElementRef, HostListener, Input, QueryList } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { BehaviorSubject, combineLatest } from 'rxjs';
 import { distinctUntilChanged, map, tap } from 'rxjs/operators';
@@ -6,7 +6,7 @@ import { RIPPLE } from '../../../../composables/ripple/ripple.provider';
 import { RippleService } from '../../../../composables/ripple/ripple.service';
 import { toBoolean } from '../../../../utils/functions';
 import { BooleanLike } from '../../../../utils/interfaces';
-import { StepperVisitedIconDirective } from '../../directives/stepper-visited-icon/stepper-visited-icon.directive';
+import { SlotDirective } from '../../../common/directives/slot/slot.directive';
 import { StepperSettings } from '../../services/stepper-settings/stepper-settings.service';
 import { Stepper } from '../../services/stepper/stepper.service';
 
@@ -19,7 +19,7 @@ import { Stepper } from '../../services/stepper/stepper.service';
   providers: [RIPPLE],
 })
 export class StepperHeaderComponent {
-  @ContentChild(StepperVisitedIconDirective) public readonly stepperVisitedIcon!: StepperVisitedIconDirective;
+  @ContentChildren(SlotDirective) public readonly slots!: QueryList<SlotDirective>;
 
   @Input()
   public set label(value: string | null) {

--- a/libs/anglify/src/modules/stepper/components/stepper/stepper.component.html
+++ b/libs/anglify/src/modules/stepper/components/stepper/stepper.component.html
@@ -7,8 +7,15 @@
     [active]="(step.selected$ | async) ?? false"
     [visited]="(step.visited$ | async) ?? false"
   >
-    <ng-template anglifyStepperVisitedIcon>
-      <ng-container [ngTemplateOutlet]="visitedIcon"></ng-container>
+    <ng-template slot="visitedIcon">
+      <ng-container *anglifySlotOutlet="slots | findSlot: 'visitedIcon'">
+        <svg width="100%" height="100%" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
+          />
+        </svg>
+      </ng-container>
     </ng-template>
   </anglify-stepper-header>
 
@@ -26,18 +33,6 @@
     </div>
   </ng-container>
 </div>
-
-<ng-template #visitedIcon>
-  <ng-container *ngIf="stepperVisitedIcon" [ngTemplateOutlet]="stepperVisitedIcon.template"></ng-container>
-  <ng-container *ngIf="!stepperVisitedIcon">
-    <svg width="100%" height="100%" viewBox="0 0 24 24">
-      <path
-        fill="currentColor"
-        d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
-      />
-    </svg>
-  </ng-container>
-</ng-template>
 
 <ng-template #stepContainer let-step>
   <div *ngIf="stepperSettings.hasStepConnectionLine$ | async" class="line-container">

--- a/libs/anglify/src/modules/stepper/components/stepper/stepper.component.ts
+++ b/libs/anglify/src/modules/stepper/components/stepper/stepper.component.ts
@@ -1,21 +1,11 @@
 import { animate, group, query, state, style, transition, trigger } from '@angular/animations';
-import {
-  AfterContentInit,
-  ChangeDetectionStrategy,
-  Component,
-  ContentChild,
-  ContentChildren,
-  ElementRef,
-  Input,
-  Output,
-  QueryList,
-} from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, Input, Output, QueryList } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { map, startWith, tap } from 'rxjs/operators';
 import { toBoolean } from '../../../../utils/functions';
 import { BooleanLike } from '../../../../utils/interfaces';
+import { SlotDirective } from '../../../common/directives/slot/slot.directive';
 import { Step } from '../../directives/step/step.directive';
-import { StepperVisitedIconDirective } from '../../directives/stepper-visited-icon/stepper-visited-icon.directive';
 import { StepperOrientation, StepperSettings } from '../../services/stepper-settings/stepper-settings.service';
 import { Stepper } from '../../services/stepper/stepper.service';
 
@@ -59,7 +49,7 @@ import { Stepper } from '../../services/stepper/stepper.service';
 })
 export class StepperComponent extends Stepper implements AfterContentInit {
   @ContentChildren(Step) private readonly _steps?: QueryList<Step>;
-  @ContentChild(StepperVisitedIconDirective) public readonly stepperVisitedIcon?: StepperVisitedIconDirective;
+  @ContentChildren(SlotDirective) public readonly slots?: QueryList<SlotDirective>;
 
   @Input()
   public set stepConnectionLine(value: BooleanLike) {

--- a/libs/anglify/src/modules/stepper/directives/stepper-visited-icon/stepper-visited-icon.directive.spec.ts
+++ b/libs/anglify/src/modules/stepper/directives/stepper-visited-icon/stepper-visited-icon.directive.spec.ts
@@ -1,8 +1,0 @@
-import { StepperVisitedIconDirective } from './stepper-visited-icon.directive';
-
-describe('StepperVisitedIconDirective', () => {
-  it('should create an instance', () => {
-    const directive = StepperVisitedIconDirective;
-    expect(directive).toBeTruthy();
-  });
-});

--- a/libs/anglify/src/modules/stepper/directives/stepper-visited-icon/stepper-visited-icon.directive.ts
+++ b/libs/anglify/src/modules/stepper/directives/stepper-visited-icon/stepper-visited-icon.directive.ts
@@ -1,8 +1,0 @@
-import { Directive, TemplateRef } from '@angular/core';
-
-@Directive({
-  selector: 'ng-template[anglifyStepperVisitedIcon]',
-})
-export class StepperVisitedIconDirective {
-  public constructor(public template: TemplateRef<any>) {}
-}

--- a/libs/anglify/src/modules/stepper/stepper.module.ts
+++ b/libs/anglify/src/modules/stepper/stepper.module.ts
@@ -5,18 +5,11 @@ import { StepperComponent } from './components/stepper/stepper.component';
 import { Step } from './directives/step/step.directive';
 import { StepperNextDirective } from './directives/stepper-next/stepper-next.directive';
 import { StepperPreviousDirective } from './directives/stepper-previous/stepper-previous.directive';
-import { StepperVisitedIconDirective } from './directives/stepper-visited-icon/stepper-visited-icon.directive';
+import { AnglifyCommonModule } from '../common/anglify-common.module';
 
 @NgModule({
-  imports: [CommonModule],
-  declarations: [
-    StepperComponent,
-    StepperHeaderComponent,
-    Step,
-    StepperNextDirective,
-    StepperPreviousDirective,
-    StepperVisitedIconDirective,
-  ],
-  exports: [StepperComponent, Step, StepperNextDirective, StepperPreviousDirective, StepperVisitedIconDirective],
+  imports: [AnglifyCommonModule, CommonModule],
+  declarations: [StepperComponent, StepperHeaderComponent, Step, StepperNextDirective, StepperPreviousDirective],
+  exports: [AnglifyCommonModule, StepperComponent, Step, StepperNextDirective, StepperPreviousDirective],
 })
 export class StepperModule {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/valentingavran/anglify/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

### BREAKING CHANGE
There were many identical directives which exported only the TemplateRef. There
were also places where no TemplateRefs were used at all (instad only normal selectors). This has
now been standardized. At the respective places one must now use
`<ng-template slot="...">...</ng-template>`. The slot name is passed via the slot attribute

# API changes (Concerns Anglify users)

Before:

```html
<anglify-checkbox checked>
  <anglify-icon onIcon icon="mdi-cards-heart"></anglify-icon>
  Check me
</anglify-checkbox>
```

```html
<anglify-form-field type="filled">
  <ng-template anglifyLabel>
    What about a icon here?
    <anglify-icon icon="mdi-email"></anglify-icon>
  </ng-template>
  <input anglifyInput />
</anglify-form-field>
```

```html
<anglify-list-item>
  <ng-template anglifyPrepend>
    <anglify-icon icon="mdi-clock"></anglify-icon>
  </ng-template>
  <anglify-list-item-title>Real time</anglify-list-item-title>
</anglify-list-item>
```

After:

```html
<anglify-checkbox checked>
  <ng-template slot="onIcon">
    <anglify-icon icon="mdi-cards-heart"></anglify-icon>
  </ng-template>
  Check me
</anglify-checkbox>
```

```html
<anglify-form-field type="filled">
  <ng-template slot="label">
    What about a icon here?
    <anglify-icon icon="mdi-email"></anglify-icon>
  </ng-template>
  <input anglifyInput />
</anglify-form-field>
```

```html
<anglify-list-item>
  <ng-template slot="prepend">
    <anglify-icon icon="mdi-clock"></anglify-icon>
  </ng-template>
  <anglify-list-item-title>Real time</anglify-list-item-title>
</anglify-list-item>
```

# Internal changes (Concerns Anglify Maintainers)

Instead of this
```html
<ng-container *ngIf="labelDirective;else: defaultValue">
  <ng-container *ngTemplateOutlet="labelDirective.template"></ng-container>
</ng-container>
<ng-template #defaultValue>
  Default label value
</ng-template>
```
```typescript
@ContentChild(LabelDirective) public readonly labelDirective?: LabelDirective;
```
you write this one liner, which uses the content between the tag as the default value (if the slot was not provided):
```html
<ng-container *anglifySlotOutlet="slots | findSlot: 'label'">Default label value</ng-container>
```
```typescript
@ContentChildren(SlotDirective) public readonly slots?: QueryList<SlotDirective>;
```